### PR TITLE
Add support for Perl Templates

### DIFF
--- a/cw-template-tt
+++ b/cw-template-tt
@@ -1,0 +1,32 @@
+#!/usr/bin/perl
+
+#
+# template-tt - Clockwork Template Toolkit Renderer
+#
+# author:  Dan Molik <dan@d3fy.net>
+# created: 2017-07-26
+#
+
+use strict;
+use warnings;
+
+use Template;
+
+my $tt = Template->new({EVAL_PERL => 1});
+open my $fh, '<', $ARGV[0] or die "unable to open $ARGV[0]: $!";
+my $template;
+while (<$fh>) {
+	$template .= $_;
+}
+close $fh;
+my ($k, $v, $l);
+my $data = {map {
+	$l = $ARGV[$_];
+	$l =~ s/\r?\n//;
+	($k, $v) = split '=', $l;
+	$k =~ s/\./_/;
+	($k, $v);
+} 1..(scalar(@ARGV) - 1)};
+$tt->process(\$template, $data);
+
+# vim:ft=perl

--- a/src/resources.c
+++ b/src/resources.c
@@ -738,7 +738,13 @@ content_t* res_file_content(const void *res, hash_t *facts)
 		rewind(runner.in);
 
 		errno = 0;
-		int rc = run2(&runner, "cw", "template-erb", r->template, NULL);
+		int rc;
+		if (strlen(r->template) > 3
+				&& strcmp(r->template + strlen(r->template) - 3, ".tt") == 0) {
+			rc = run2(&runner, "cw", "template-tt",  r->template, NULL);
+		} else {
+			rc = run2(&runner, "cw", "template-erb", r->template, NULL);
+		}
 		fclose(runner.in);
 
 		if (rc == 0) {


### PR DESCRIPTION
This change adds support for Template-Toolkit templates
(http://www.template-toolkit.org/) and adds checking in resources.c
for the templates filename, and if the template's path ends in '.erb'
then the old cw-template-erb is used, otherwise cw-template-tt is
the default template render engine.