### PR TITLE
Include sys/sysmacros.h in vm.c

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 #include <ctype.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <dirent.h>


### PR DESCRIPTION
major and minor were undefined.

From https://sourceware.org/ml/libc-alpha/2017-02/msg00079.html
* The inclusion of <sys/sysmacros.h> by <sys/types.h> is deprecated.
  This means that in a future release, the macros “major”, “minor”, and
  “makedev” will only be available from <sys/sysmacros.h>.