### PR TITLE
Remove headers from t/test-cmd

### DIFF
--- a/t/test-cmd.c
+++ b/t/test-cmd.c
@@ -17,9 +17,6 @@
   along with Clockwork.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "test.h"
-#include "../src/mesh.h"
-
 #include "../src/mesh.h"
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
on compilation the following errors were occuring:
```
t/test-cmd.c:29:5: error: redefinition of ‘main’
 int main(int argc, char **argv)
     ^~~~
In file included from t/test.h:23:0,
                 from t/test-cmd.c:20:
/usr/include/ctap.h:410:5: note: previous definition of ‘main’ was here
 int main(int argc, char **argv)
```